### PR TITLE
Updates to best practice for certificate generation

### DIFF
--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -188,7 +188,7 @@ The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for eve
 
 The device manufacturer SHOULD populate the TLS Client Certificate "serialNumber" attribute with the device's unique serial number from [RFC 5280 - Section 4.1.2.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.2)'s list of standard attributes.
 
-The device manufacturer MUST make the public key of the CA available to the customer network  administrators. It is RECOMMENDED that manufacturers maintain a public Certificate Revocation List (CRL) and OCSP server.
+The device manufacturer MUST make the public key of the CA available to the customer network administrators. It is RECOMMENDED that manufacturers maintain a public Certificate Revocation List (CRL) and OCSP server.
 
 An EST Client SHOULD allow EST to be disabled, preventing the EST Client from being automatically provisioned with a TLS Certificate if required by the network's security policy. The default value SHOULD be EST **Enabled**.
 
@@ -204,7 +204,7 @@ An EST Client MUST provide a method to manually install both the Root Certificat
 
 An EST Client MUST provide a method to replace the manufacturer-issued TLS Client Certificate, for the case when the TLS Certificate has been revoked or expired.
 
-An EST Client MAY ignore all time stamps in the certificate validity periods during the certificate provisioning process if it does not know the current time, see [Bootstrapping Remote Secure Key Infrastructures - Section 2.6.1](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-2.6.1) for more information.
+An EST Client MAY ignore all timestamps in the certificate validity periods during the certificate provisioning process if it does not know the current time, see [Bootstrapping Remote Secure Key Infrastructures - Section 2.6.1](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-2.6.1) for more information.
 
 If the EST Server returns a HTTP re-direct, the the EST Client SHOULD follow the re-direct URL, re-negotiating the TLS session when appropriate.
 
@@ -250,7 +250,7 @@ Before using the returned TLS certificate the EST Client SHOULD validate the TLS
 
 If the EST Server returns a HTTP 202 or 503, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
 
-[RFC 7030 Section 4.2.3](https://tools.ietf.org/html/rfc7030#section-4.2.3)
+[RFC 7030 - Section 4.2.3](https://tools.ietf.org/html/rfc7030#section-4.2.3)
 
 #### Certificate Request Error Response
 
@@ -308,8 +308,7 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 
 ## Notes to Implementers
 
-- The Random Number Generator (RNG) used to generate keys for each digital signature suite SHOULD have sufficient entropy to generate keys with the required length
-  - More information about RNG can be found in [NIST SP 800-90A][NIST SP 800-90A]
+- EST Clients MUST have access to a good source of randomness in an acceptable amount of time, for more information on achieving this see [BRSKI - Section 5.9.4](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-5.9.4) and [RFC 4086 - Randomness Requirements for Security][RFC-4086].
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
@@ -340,6 +339,8 @@ The IETF RFCs referenced here provide much more information.
 
 [RFC 2986][RFC-2986] - PKCS #10: Certification Request Syntax Specification
 
+[RFC 4086][RFC-4086] - Randomness Requirements for Security
+
 [RFC 4210][RFC-4210] - Internet X.509 Public Key Infrastructure Certificate Management Protocol (CMP)
 
 [RFC 5280][RFC-5280] - Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
@@ -367,6 +368,8 @@ The IETF RFCs referenced here provide much more information.
 [RFC-2782]: https://tools.ietf.org/html/rfc2782
 
 [RFC-2986]: https://tools.ietf.org/html/rfc2986
+
+[RFC-4086]: https://tools.ietf.org/html/rfc4086
 
 [RFC-4210]: https://tools.ietf.org/html/rfc4210
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -182,6 +182,8 @@ It is RECOMMENDED that the EST Server signs the TLS Certificate using an RSA key
 
 The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for every device. It is RECOMMENDED that the client certificate be valid for a maximum of 10 years, however the certificate SHOULD NOT constrain the device's lifetime. The Root CA used to sign the client certificate, is RECOMMENDED to be valid for a maximum of 20 years.
 
+The device manufacturer MUST make the public key of the CA available to the customer network  administrators. It is RECOMMENDED that manufacturers maintain a public Certificate Revocation List (CRL).
+
 An EST Client SHOULD allow EST to be disabled, preventing the EST Client from being automatically provisioned with a TLS Certificate if required by the network's security policy. The default value SHOULD be EST **Enabled**.
 
 An EST Client SHOULD allow manual configuration of the EST Server's Hostname, Port and Arbitrary Label, to prevent the EST Client from requesting a TLS Certificate from a rogue server. The default value SHOULD be **Not Set**, enabling DNS-SD discovery.
@@ -210,7 +212,7 @@ On connection to the target environment's network the EST Client SHOULD attempt 
 
 #### Get Root CA
 
-There are two possible workflows to getting the Root CA depending on if explicit trust of EST server is enabled or disabled.
+There are two possible workflows to getting the Root CA for the target network depending on if explicit trust of EST server is **Enabled** or **Disabled**.
 
 If explicit trust of the EST Server is **Enabled**, the EST Client SHOULD make a HTTPS request to the `/cacerts` endpoint of the EST Server for the latest Root CA of the current network. The EST Client SHOULD explicitly trust the EST Server manually configured or discovered using Unicast DNS and not perform authentication of the EST Server's TLS Certificate during the initial request to the EST Server.
 
@@ -218,11 +220,11 @@ If explicit trust of the EST Server is **Disabled**, the EST Client SHOULD make 
 
 If the EST Server returns a HTTP 200 response, the EST Client SHOULD add the returned Root CA to the list of trusted Certificate authorities, replacing any previously installed Root CAs which were obtained via EST. It SHOULD also store any intermediate certificates returned, which are used to form the chain of trust for certificates issued by the EST CA.
 
-The EST Client MUST be able to handle the  three "Root CA Key Update" certificates OldWithOld, OldWithNew, and NewWithOld in the response, defined in Section 4.4 of [RFC 4210][RFC-4210].
+The EST Client MUST be able to handle the three "Root CA Key Update" certificates OldWithOld, OldWithNew, and NewWithOld in the response, defined in Section 4.4 of [RFC 4210][RFC-4210].
 
 #### Generate Certificate Signing(CSR) Request
 
-The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name that is resolvable via DNS on the current domain and appropriate values for the other CSR fields. The manufacturer MAY allow the optional CSR fields to be configured by the operator. The EST Client MAY use an existing private key to sign the CSR, if the private key has been compromised the EST Client MUST generate a new pair to sign the CSR.
+The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Name that is resolvable via DNS on the current domain and appropriate values for the other CSR fields. The manufacturer MAY allow the optional CSR fields to be configured by the operator. The EST Client MAY use an existing private key to sign the CSR, if the private key has been compromised the EST Client MUST generate a new pair to sign the CSR.
 
 The CSR request SHOULD include information specific to the current authenticated TLS session within the signed CSR, this is to prevent man in the middle attacks. More information about the linking of identity and proof-of possession can be found in Section 3.5 of [RFC 7030][RFC-7030].
 
@@ -232,9 +234,17 @@ For each generated CSR the EST Client SHOULD make a HTTPS request containing the
 
 #### Certificate Request Response
 
-If the EST Server returns a HTTP 200 response the certificate request was successful and the EST Client should use the returned TLS Certificate and its chain of trust for all further requests to NMOS APIs. The EST Client MUST remove any previously issued TLS Certificates and keys.
+If the EST Server returns a HTTP 200 response the certificate request was successful and the response from the EST Server SHOULD contain a valid TLS certificate.
 
-If the EST Server returns a HTTP 202, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting the certificate request and attempting with an a alternative EST Server. [RFC 7030 Section 4.2.3](https://tools.ietf.org/html/rfc7030#section-4.2.3)
+Before using the returned TLS certificate the EST Client SHOULD validate the TLS certificate, validating for example the; NotBefore, Not After, Common Name, Subject Alt Name and chain of trust. The validity of the TLS certificate could checked by installing the certificate and performing a request to the API.
+
+If the TLS certificate is successfully validated the TLS Certificate and its chain of trust SHOULD be used for all further requests to the NMOS APIs. The EST Client MUST remove any previously issued TLS Certificates and keys. If the EST Client fails to validate the TLS certificate the certificate SHOULD not be used and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
+
+If the EST Server returns a HTTP 202, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
+
+[RFC 7030 Section 4.2.3](https://tools.ietf.org/html/rfc7030#section-4.2.3)
+
+#### Certificate Request Error Response
 
 If the EST Server returns any other HTTP response, the request has been unsuccessful, this could be caused by a malformed request, server side error or the EST Client not being authorised. The EST Client SHOULD restart the EST workflow with an alternative EST Server if present, else the EST Client SHOULD implement an exponential backoff algorithm, with a staring period of 1 second before retrying.
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -200,7 +200,7 @@ An EST Client MUST provide a method to replace the manufacturer-issued TLS Clien
 
 If the EST Server returns a HTTP re-direct, the the EST Client SHOULD follow the re-direct URL, re-negotiating the TLS session when appropriate.
 
-If the EST Server returns a HTTP 202 with a Retry-After header, the EST Client SHOULD not attempt the HTTP request again until the period defined in the header has expired.
+If the EST Server returns a HTTP 202 or 503 with a Retry-After header, the EST Client SHOULD not attempt the HTTP request again until the period defined in the header has expired.
 
 If the EST Server returns an HTTP 4xx, HTTP 5xx or Connection Timeout, the EST Client SHOULD attempt the request again using an alternative EST Server if present, else the EST Client SHOULD wait an appropriate exponential backoff period before retrying.
 
@@ -212,7 +212,7 @@ On connection to the target environment's network the EST Client SHOULD attempt 
 
 #### Get Root CA
 
-There are two possible workflows to getting the Root CA for the target network depending on if explicit trust of EST server is **Enabled** or **Disabled**.
+There are two possible workflows for installing the Root CA for the target network depending on if explicit trust of EST server is **Enabled** or **Disabled**.
 
 If explicit trust of the EST Server is **Enabled**, the EST Client SHOULD make a HTTPS request to the `/cacerts` endpoint of the EST Server for the latest Root CA of the current network. The EST Client SHOULD explicitly trust the EST Server manually configured or discovered using Unicast DNS and not perform authentication of the EST Server's TLS Certificate during the initial request to the EST Server.
 
@@ -240,7 +240,7 @@ Before using the returned TLS certificate the EST Client SHOULD validate the TLS
 
 If the TLS certificate is successfully validated the TLS Certificate and its chain of trust SHOULD be used for all further requests to the NMOS APIs. The EST Client MUST remove any previously issued TLS Certificates and keys. If the EST Client fails to validate the TLS certificate the certificate SHOULD not be used and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
 
-If the EST Server returns a HTTP 202, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
+If the EST Server returns a HTTP 202 or 503, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
 
 [RFC 7030 Section 4.2.3](https://tools.ietf.org/html/rfc7030#section-4.2.3)
 
@@ -282,7 +282,7 @@ Renewal of the TLS Certificate can either be performed using the existing privat
 
 ### Expired Manufacturer Issued TLS Client Certificate
 
-If the manufacturer issued TLS Client Certificate has expired or has been revoked, it MUST NOT be used by the EST Client for authentication. An EST Client MAY attempt to request a TLS Certificate following [Initial Certificate Provisioning](#initial-certificate-provisioning), without providing a TLS Client Certificate during the TLS handshake. If the EST Server supports manual authentication the request will be processed once the manual authentication has been granted.
+If the manufacturer issued TLS Client Certificate has expired or has been revoked, it MUST NOT be used by the EST Client for authentication. An EST Client MAY attempt to request a TLS Certificate following [Initial Certificate Provisioning](#initial-certificate-provisioning), without providing a TLS Client Certificate during the TLS handshake. If the EST Server supports manual authentication the request will be processed once manual authentication has been granted.
 
 If the EST Server fails to process the request the following actions MAY be taken:
 1. The EST Client MAY have a TLS Certificate for the target network manually installed on the device. The manually installed TLS certificate MUST then be used to secure its NMOS APIs until the TLS Certificate is due for renewal. The manually installed TLS Certificate MUST be presented during the TLS Handshake for [Certificate Renewals](#certificate-renewal). If the certificate renewal is successful, the manually installed TLS Certificate and private key MUST be removed
@@ -301,10 +301,10 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 ## Notes to Implementers
 
 - The Random Number Generator (RNG) used to generate keys for each digital signature suite SHOULD have sufficient entropy to generate keys with the required length
-  - More information about RNG can be found in [NIST SP 800-90A]
+  - More information about RNG can be found in [NIST SP 800-90A][NIST SP 800-90A]
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
-- Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect primary operation of the device).
+- Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
 
 ## Security Considerations
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -155,7 +155,8 @@ The EST Server MAY also support manual authentication of the EST Client if:
 - No TLS Client Certificate is presented during the TLS handshake
 - The TLS Client Certificate is not trusted
 - The local security policy requires an extra authentication step
-The exact process for manual authentication will be implementation specific, but the EST Server MUST provide enough information to the operator so they can authenticate the EST Client. During the manual authentication the EST Server MUST respond with either HTTP 202 or HTTP 503 and the response MUST include a `Retry-After` header.
+
+The exact process for manual authentication will be implementation specific, but the EST Server MUST provide enough information to the operator so they can authenticate the EST Client. During manual authentication the EST Server MUST respond with HTTP 202 and the response MUST include a `Retry-After` header as defined for HTTP 503 responses.
 
 The EST Server MUST not support Basic HTTP Authentication.
 
@@ -167,7 +168,7 @@ The EST Server MUST return a TLS Certificate with the Extended Key Usage set for
 
 The EST Server MAY support the server side generated key endpoint `/serverkeygen`, which SHOULD be implemented in accordance with [RFC 7030](https://tools.ietf.org/html/rfc7030#section-4.4). This endpoint allows devices unable to generate their own key pair with the required entropy, to request a TLS certificate.
 
-If the server side generated key endpoint is supported the EST Server MUST perform client authentication and authorisation as per [EST Server - Client Authentication](#est-server---client-authentication).
+If the server side generated key endpoint is supported, the EST Server MUST perform client authentication and authorisation as per [EST Server - Client Authentication](#est-server---client-authentication).
 
 If the EST Client is authenticated and authorised, the EST Server MUST return the TLS Certificate and private key used to sign the certificate.
 
@@ -179,7 +180,7 @@ It is RECOMMENDED that the EST Server signs the TLS Certificate using an RSA key
 
 ## EST Client
 
-The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for every device. It is RECOMMENDED that this certificate be valid for a maximum of 10 years. The Root CA used to sign it, is RECOMMENDED to be valid for a maximum of 20 years.
+The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for every device. It is RECOMMENDED that the client certificate be valid for a maximum of 10 years, however the certificate SHOULD NOT constrain the device's lifetime. The Root CA used to sign the client certificate, is RECOMMENDED to be valid for a maximum of 20 years.
 
 An EST Client SHOULD allow EST to be disabled, preventing the EST Client from being automatically provisioned with a TLS Certificate if required by the network's security policy. The default value SHOULD be EST **Enabled**.
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -224,7 +224,7 @@ The EST Client MUST be able to handle the three "Root CA Key Update" certificate
 
 #### Generate Certificate Signing(CSR) Request
 
-The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Name that is resolvable via DNS on the current domain and appropriate values for the other CSR fields. The manufacturer MAY allow the optional CSR fields to be configured by the operator. The EST Client MAY use an existing private key to sign the CSR, if the private key has been compromised the EST Client MUST generate a new pair to sign the CSR.
+The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Name that is resolvable via DNS on the current domain and appropriate values for the other CSR fields. The EST Client MUST generate a new key pair to sign the CSR.
 
 The CSR request SHOULD include information specific to the current authenticated TLS session within the signed CSR, this is to prevent man in the middle attacks. More information about the linking of identity and proof-of possession can be found in Section 3.5 of [RFC 7030][RFC-7030].
 
@@ -260,7 +260,8 @@ EST Client SHOULD handle the EST Server's response as per [Certificate Request R
 
 ### Root Certificate Authority Renewal
 
-Renewal of the Root CA SHOULD be attempted no sooner than 50% of the certificate's expiry time. It is RECOMMENDED that certificate renewal is performed after 80% of the expiry time. To renew the Root CA and the EST Client's TLS Certificate follow the [Initial Certificate Provisioning](#initial-certificate-provisioning) workflow, using the existing TLS Certificate for authentication if still valid.
+Renewal of the Root CA SHOULD be attempted no sooner than 50% of the certificate's expiry time. It is RECOMMENDED that certificate renewal is performed after 80% of the expiry time. To renew the Root CA and the EST Client's TLS Certificate follow the [Initial Certificate Provisioning](#initial-certificate-provisioning) workflow, renewing both the Root CA and server certificates in the process.
+
 If the returned Root Certificate Authority by the EST Server is the same as the existing Root Certificate Authority, the EST Client SHOULD re-attempt renewal of the Root Certificate Authority after half of the remaining period of validity has elapsed.
 
 ### EST Server Side Key Generation
@@ -281,7 +282,7 @@ Renewal of the TLS Certificate can either be performed using the existing privat
 
 ### Expired Manufacturer Issued TLS Client Certificate
 
-If the manufacturer issued TLS Client Certificate has expired or has been revoked, it MUST NOT be used by the EST Client for authentication. An EST Client MAY attempt to request a TLS Certificate following [Initial Certificate Provisioning](#initial-certificate-provisioning), without providing a TLS Client Certificate during the TLS handshake. If the EST Server supports manual authentication the request will be processed.
+If the manufacturer issued TLS Client Certificate has expired or has been revoked, it MUST NOT be used by the EST Client for authentication. An EST Client MAY attempt to request a TLS Certificate following [Initial Certificate Provisioning](#initial-certificate-provisioning), without providing a TLS Client Certificate during the TLS handshake. If the EST Server supports manual authentication the request will be processed once the manual authentication has been granted.
 
 If the EST Server fails to process the request the following actions MAY be taken:
 1. The EST Client MAY have a TLS Certificate for the target network manually installed on the device. The manually installed TLS certificate MUST then be used to secure its NMOS APIs until the TLS Certificate is due for renewal. The manually installed TLS Certificate MUST be presented during the TLS Handshake for [Certificate Renewals](#certificate-renewal). If the certificate renewal is successful, the manually installed TLS Certificate and private key MUST be removed
@@ -299,10 +300,11 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 
 ## Notes to Implementers
 
-- The key pairs generated MUST have a good source generated
+- The Random Number Generator (RNG) used to generate keys for each digital signature suite SHOULD have sufficient entropy to generate keys with the required length
+  - More information about RNG can be found in [NIST SP 800-90A]
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
-- Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients).
+- Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect primary operation of the device).
 
 ## Security Considerations
 
@@ -317,6 +319,8 @@ Bootstrap Distribution of CA Certificate:
 ## Further Reading
 
 The IETF RFCs referenced here provide much more information.
+
+[NIST SP 800-90A][NIST SP 800-90A] - Recommendation for Random Number Generation Using Deterministic Random Bit Generators
 
 [RFC 2119][RFC-2119] - Key words for use in RFCs to Indicate Requirement Levels
 
@@ -341,6 +345,8 @@ The IETF RFCs referenced here provide much more information.
 [RFC 7030][RFC-7030] - Enrollment over Secure Transport
 
 [BCP-003-01]: https://amwa-tv.github.io/nmos-secure-communication/
+
+[NIST SP 800-90A]: http://dx.doi.org/10.6028/NIST.SP.800-90Ar1
 
 [RFC-2119]: https://tools.ietf.org/html/rfc2119
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -149,7 +149,11 @@ The EST Server MUST present a valid TLS Server Certificate, this Certificate MUS
 
 The EST Server MUST authenticate the EST Client that is requesting a TLS Certificate manually or automatically using a TLS Client Certificate.
 
-The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request. The EST Server MUST provide a method to load multiple trusted Root CA's, that are used to verify the TLS Client Certificate.
+The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request.
+
+As the TLS Client Certificate is intended to be used for the lifetime of the device, the EST Server MUST support the GeneralizedTime value of 99991231235959Z for the notAfter field as defined in [RFC 5280 - Section 4.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.5). The EST Server MAY also ignore the validity period of the client certificate and authenticate a EST Client using an expired client certificate.
+
+The EST Server MUST provide a method to load multiple trusted Root CA's, that are used to verify the TLS Client Certificate.
 
 The EST Server MAY also support manual authentication of the EST Client if:
 - No TLS Client Certificate is presented during the TLS handshake
@@ -166,7 +170,7 @@ The EST Server MUST return a TLS Certificate with the Extended Key Usage set for
 
 ### EST Server Side Key Generation
 
-The EST Server MAY support the server side generated key endpoint `/serverkeygen`, which SHOULD be implemented in accordance with [RFC 7030](https://tools.ietf.org/html/rfc7030#section-4.4). This endpoint allows devices unable to generate their own key pair with the required entropy, to request a TLS certificate.
+The EST Server MAY support the server side generated key endpoint `/serverkeygen`, which SHOULD be implemented in accordance with [RFC 7030 - Section 4.4](https://tools.ietf.org/html/rfc7030#section-4.4). This endpoint allows devices unable to generate their own key pair with the required entropy, to request a TLS certificate.
 
 If the server side generated key endpoint is supported, the EST Server MUST perform client authentication and authorisation as per [EST Server - Client Authentication](#est-server---client-authentication).
 
@@ -180,9 +184,11 @@ It is RECOMMENDED that the EST Server signs the TLS Certificate using an RSA key
 
 ## EST Client
 
-The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for every device. It is RECOMMENDED that the client certificate be valid for a maximum of 10 years, however the certificate SHOULD NOT constrain the device's lifetime. The Root CA used to sign the client certificate, is RECOMMENDED to be valid for a maximum of 20 years.
+The EST Client manufacturer SHOULD issue a unique TLS Client Certificate for every device. It is RECOMMENDED that the notAfter value be set to the GeneralizedTime value of 99991231235959Z, defined in [RFC 5280 - Section 4.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.5) for when a certificate is intended to be used for the entire lifetime of the device. All certificates in the chain of trust MUST also have their NotAfter value set to the GeneralizedTime value of 99991231235959Z. A client certificate and chain of trust with the notAfter value set to the GeneralizedTime value of 99991231235959Z, MUST not be used for anything other than Client authentication.
 
-The device manufacturer MUST make the public key of the CA available to the customer network  administrators. It is RECOMMENDED that manufacturers maintain a public Certificate Revocation List (CRL).
+The device manufacturer SHOULD populate the TLS Client Certificate "serialNumber" attribute with the device's unique serial number from [RFC 5280 - Section 4.1.2.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.2)'s list of standard attributes.
+
+The device manufacturer MUST make the public key of the CA available to the customer network  administrators. It is RECOMMENDED that manufacturers maintain a public Certificate Revocation List (CRL) and OCSP server.
 
 An EST Client SHOULD allow EST to be disabled, preventing the EST Client from being automatically provisioned with a TLS Certificate if required by the network's security policy. The default value SHOULD be EST **Enabled**.
 
@@ -197,6 +203,8 @@ An EST Client MAY maintain a database of implicitly trusted Certificate Authorit
 An EST Client MUST provide a method to manually install both the Root Certificate Authority and TLS Server certificate for the target environment, for the case when an EST Server is not present or the TLS Client Certificate is no longer valid.
 
 An EST Client MUST provide a method to replace the manufacturer-issued TLS Client Certificate, for the case when the TLS Certificate has been revoked or expired.
+
+An EST Client MAY ignore all time stamps in the certificate validity periods during the certificate provisioning process if it does not know the current time, see [Bootstrapping Remote Secure Key Infrastructures - Section 2.6.1](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-2.6.1) for more information.
 
 If the EST Server returns a HTTP re-direct, the the EST Client SHOULD follow the re-direct URL, re-negotiating the TLS session when appropriate.
 
@@ -220,13 +228,15 @@ If explicit trust of the EST Server is **Disabled**, the EST Client SHOULD make 
 
 If the EST Server returns a HTTP 200 response, the EST Client SHOULD add the returned Root CA to the list of trusted Certificate authorities, replacing any previously installed Root CAs which were obtained via EST. It SHOULD also store any intermediate certificates returned, which are used to form the chain of trust for certificates issued by the EST CA.
 
-The EST Client MUST be able to handle the three "Root CA Key Update" certificates OldWithOld, OldWithNew, and NewWithOld in the response, defined in Section 4.4 of [RFC 4210][RFC-4210].
+The EST Client MUST be able to handle the three "Root CA Key Update" certificates OldWithOld, OldWithNew, and NewWithOld in the response, defined in [RFC 4210 - Section 4.4](https://tools.ietf.org/html/rfc4210#section-4.4).
 
 #### Generate Certificate Signing(CSR) Request
 
-The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Name that is resolvable via DNS on the current domain and appropriate values for the other CSR fields. The EST Client MUST generate a new key pair to sign the CSR.
+The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Names that are resolvable via DNS on the current domain and appropriate values for the other CSR fields. The EST Client MUST generate a new key pair to sign the CSR.
 
-The CSR request SHOULD include information specific to the current authenticated TLS session within the signed CSR, this is to prevent man in the middle attacks. More information about the linking of identity and proof-of possession can be found in Section 3.5 of [RFC 7030][RFC-7030].
+The CSR request SHOULD populate the "serialNumber" attribute with the device's unique serial number from [RFC 5280 - Section 4.1.2.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.2)'s list of standard attributes.
+
+The CSR request SHOULD include information specific to the current authenticated TLS session within the signed CSR, this is to prevent man in the middle attacks. More information about the linking of identity and proof-of possession can be found in [RFC 7030 - Section 3.5](https://tools.ietf.org/html/rfc7030#section-3.5).
 
 #### Certificate Request
 
@@ -236,9 +246,7 @@ For each generated CSR the EST Client SHOULD make a HTTPS request containing the
 
 If the EST Server returns a HTTP 200 response the certificate request was successful and the response from the EST Server SHOULD contain a valid TLS certificate.
 
-Before using the returned TLS certificate the EST Client SHOULD validate the TLS certificate, validating for example the; NotBefore, Not After, Common Name, Subject Alt Name and chain of trust. The validity of the TLS certificate could checked by installing the certificate and performing a request to the API.
-
-If the TLS certificate is successfully validated the TLS Certificate and its chain of trust SHOULD be used for all further requests to the NMOS APIs. The EST Client MUST remove any previously issued TLS Certificates and keys. If the EST Client fails to validate the TLS certificate the certificate SHOULD not be used and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
+Before using the returned TLS certificate the EST Client SHOULD validate the TLS certificate, validating for example the; NotBefore, Not After, Common Name, Subject Alt Name and chain of trust. The validity of the TLS certificate could be checked by installing the certificate and performing a request to the API. If the TLS certificate is successfully validated, the TLS Certificate and its chain of trust SHOULD be used for all further requests to the NMOS APIs. The EST Client MUST remove any previously issued TLS Certificates and keys. If the EST Client fails to validate the TLS certificate the certificate SHOULD not be used and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
 
 If the EST Server returns a HTTP 202 or 503, the request was accepted, but the certificate has not been processed yet. The response SHOULD include a `Retry-After` header and the EST Client MUST not attempt re-sending the request before the defined time has expired. If the TLS session is renegotiated and the CSR includes identity linking information, the CSR will need to be re-generated. The EST Client SHOULD attempt resending the request an appropriate number times before aborting and the [Certificate Request Error Response](#certificate-request-error-response) workflow followed.
 
@@ -268,7 +276,7 @@ If the returned Root Certificate Authority by the EST Server is the same as the 
 
 An EST Server MAY support server side key generation, allowing devices to request a TLS Certificate without having to perform the computationally expensive process of generating a private key.
 
-If the EST Server supports server side key generation, the EST Client MAY make a request to the EST Server endpoint `/serverkeygen` in accordance with Section 4.4 in [RFC 7030](https://tools.ietf.org/html/rfc7030#section-4.4).
+If the EST Server supports server side key generation, the EST Client MAY make a request to the EST Server endpoint `/serverkeygen` in accordance with [RFC 7030 - Section 4.4](https://tools.ietf.org/html/rfc7030#section-4.4).
 
 The EST Client SHOULD request that the returned private key is encrypted using either symmetric or asymmetric encryption, by including the appropriate information in the CSR.
 
@@ -320,6 +328,8 @@ Bootstrap Distribution of CA Certificate:
 
 The IETF RFCs referenced here provide much more information.
 
+[BRSKI][BRSKI] - Bootstrapping Remote Secure Key Infrastructures (BRSKI)
+
 [NIST SP 800-90A][NIST SP 800-90A] - Recommendation for Random Number Generation Using Deterministic Random Bit Generators
 
 [RFC 2119][RFC-2119] - Key words for use in RFCs to Indicate Requirement Levels
@@ -345,6 +355,8 @@ The IETF RFCs referenced here provide much more information.
 [RFC 7030][RFC-7030] - Enrollment over Secure Transport
 
 [BCP-003-01]: https://amwa-tv.github.io/nmos-secure-communication/
+
+[BRSKI]: https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41
 
 [NIST SP 800-90A]: http://dx.doi.org/10.6028/NIST.SP.800-90Ar1
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -151,7 +151,7 @@ The EST Server MUST authenticate the EST Client that is requesting a TLS Certifi
 
 The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request.
 
-As the TLS Client Certificate is intended to be used for the lifetime of the device, the EST Server MUST support the GeneralizedTime value of 99991231235959Z for the notAfter field as defined in [RFC 5280 - Section 4.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.5). The EST Server MAY also ignore the validity period of the client certificate and authenticate a EST Client using an expired client certificate.
+As the TLS Client Certificate is intended to be used for the lifetime of the device, the EST Server MUST support the GeneralizedTime value of 99991231235959Z for the notAfter field as defined in [RFC 5280 - Section 4.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.5). The EST Server MAY also ignore the validity period of the client certificate and authenticate an EST Client using an expired client certificate.
 
 The EST Server MUST provide a method to load multiple trusted Root CA's, that are used to verify the TLS Client Certificate.
 
@@ -204,7 +204,7 @@ An EST Client MUST provide a method to manually install both the Root Certificat
 
 An EST Client MUST provide a method to replace the manufacturer-issued TLS Client Certificate, for the case when the TLS Certificate has been revoked or expired.
 
-An EST Client MAY ignore all timestamps in the certificate validity periods during the certificate provisioning process if it does not know the current time, see [Bootstrapping Remote Secure Key Infrastructures - Section 2.6.1](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-2.6.1) for more information.
+An EST Client MAY ignore all timestamps in the certificate validity periods during the certificate provisioning process if it does not accurately know the current time, see [Bootstrapping Remote Secure Key Infrastructures - Section 2.6.1](https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-41#section-2.6.1) for more information.
 
 If the EST Server returns a HTTP re-direct, the the EST Client SHOULD follow the re-direct URL, re-negotiating the TLS session when appropriate.
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -288,6 +288,7 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 
 ## Notes to Implementers
 
+- The key pairs generated MUST have a good source generated
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients).


### PR DESCRIPTION
Changes:

- Correct formatting
- Manufacturer Client cert expiry date - notAfter date set undefined
    - EST server should support this value
    - Should the EST server also ignore the validity date? Not likely to be support for this by default
- EST Client - Lack of stable time source
    - Should ignore certificate validity of EST Server during certificate provisioning
    - eg. allow it to communicate with the EST Server while the client does not have a stable time source
- EST Client Serial Number
    - Include in the manufacturer client cert
    - Include in th CSR sent to EST server - may not be used by EST server at the moment
- Fallback procedure if EST Client fails to renew cert
    - Should carry on using existing cert and retry
- Source of entropy definition
