### PR TITLE
Add warning about Base64 line feeds for implementers

### DIFF
--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -312,6 +312,8 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
+- The Base64 encoded certificates returned by an EST Server MAY or MAY NOT be limited to 76 characters per line, as this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1), the lack of line feeds every 76 characters can cause issues with some decoder implementations
+  - EST Clients MUST be capable of handling and decoding both formats of Base64 encoded data
 
 ## Security Considerations
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -312,8 +312,8 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
-- The Base64 encoded certificates returned by an EST Server may be limited to 76 characters per line, but this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1), the lack of line feeds every 76 characters can cause issues with some decoder implementations
-  - EST Clients MUST be capable of handling and decoding both formats of Base64 encoded data
+- Some Base64 decoding libraries expect a line length of 64 characters, however this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1) and some EST Server implementations do not limit the line length of encoded data.
+  - EST Clients MUST be able to decode Base64 data that is not limited to 64 characters per line
 
 ## Security Considerations
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -312,7 +312,7 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
-- The Base64 encoded certificates returned by an EST Server MAY or MAY NOT be limited to 76 characters per line, as this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1), the lack of line feeds every 76 characters can cause issues with some decoder implementations
+- The Base64 encoded certificates returned by an EST Server may be limited to 76 characters per line, but this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1), the lack of line feeds every 76 characters can cause issues with some decoder implementations
   - EST Clients MUST be capable of handling and decoding both formats of Base64 encoded data
 
 ## Security Considerations


### PR DESCRIPTION

Added warning in 'Note to implementers' section as is not something special about the NMOS implementation it is a general word of warning and applies to all decoding of base64 encoded data

Close #3 