### PR TITLE
Define the minimum hashing algorithm to be used when signing the CSR.

### DIFF
--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -232,7 +232,11 @@ The EST Client MUST be able to handle the three "Root CA Key Update" certificate
 
 #### Generate Certificate Signing(CSR) Request
 
-The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Names that are resolvable via DNS on the current domain and appropriate values for the other CSR fields. The EST Client MUST generate a new key pair to sign the CSR.
+The EST Client SHOULD create a CSR for each digital signature algorithm it supports, with an appropriate Key Length. The CSR MUST contain a Common Name and Subject Alt Names that are resolvable via DNS on the current domain and appropriate values for the other CSR fields.
+
+The EST Client MUST generate a new key pair every time a CSR is generated.
+
+The EST Client MUST NOT use the following hashing algorithms; MD5, SHA-0 or SHA-1 as they are no longer considered secure. EST Clients SHOULD use SHA-2 or higher, until a security vulnerability is discovered and an alternative hashing algorithm is recommended or defined in the relevant TLS specification. [NIST Policy on Hash Functions](https://csrc.nist.gov/projects/hash-functions/nist-policy-on-hash-functions).
 
 The CSR request SHOULD populate the "serialNumber" attribute with the device's unique serial number from [RFC 5280 - Section 4.1.2.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.2)'s list of standard attributes.
 


### PR DESCRIPTION
A list of deprecated hashing algorithms, that should not be used as
they are considered insecure.
Definition of the minimum hashing algorithm of SHA-2 to be used,
with the limitation that the lastest guidence on recomended
hashing alogrithms shoudl be followed.

Did not include a mention of AEAD due to its limited adoption

Close #4 