### PR TITLE
Add mitigation for low power device renewals

### DIFF
--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -194,7 +194,7 @@ An EST Client SHOULD allow EST to be disabled, preventing the EST Client from be
 
 An EST Client SHOULD allow manual configuration of the EST Server's Hostname, Port and Arbitrary Label, to prevent the EST Client from requesting a TLS Certificate from a rogue server. The default value SHOULD be **Not Set**, enabling DNS-SD discovery.
 
-An EST Client SHOULD allow explicit trust of EST server to be disable, to prevent the EST Client from requesting a TLS Certificate from a rogue server. The default value SHOULD be explicit trust of EST Server **Enabled**. More information about explicit trust of an EST Server can be found in the [Get Root CA](#get-root-ca) section.
+An EST Client SHOULD allow explicit trust of EST server to be disable, to prevent the EST Client from requesting a TLS Certificate from a rogue EST Server. The default value SHOULD be explicit trust of EST Server **Enabled**. More information about explicit trust of an EST Server can be found in the [Get Root CA](#get-root-ca) section.
 
 An EST Client MAY allow an externally generated private keys to be loaded and used to sign CSR's, this is intended to support low power devices that are unable to generate their own private key. Care SHOULD be taken to maintain the confidentiality of the private keys externally generated and loaded on the device.
 
@@ -329,6 +329,7 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
+- If an EST Client cannot perform certificate renewal without affecting user operation in a critical way, then EST MAY be automatically disabled after successful certificate enrolments, preventing a renewal while the device is in use. System administrator MUST then monitor the certificate expiry and enable EST at a suitable time, forcing the EST Client to perform an enrolment.
 - Some Base64 decoding libraries expect a line length of 64 characters, however this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1) and some EST Server implementations do not limit the line length of encoded data.
   - EST Clients MUST be able to decode Base64 data that is not limited to 64 characters per line
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -192,6 +192,8 @@ The device manufacturer MUST make the public key of the CA available to the cust
 
 An EST Client SHOULD allow EST to be disabled, preventing the EST Client from being automatically provisioned with a TLS Certificate if required by the network's security policy. The default value SHOULD be EST **Enabled**.
 
+An EST CLient MUST provide a configuration option to prevent automatic renewal of its TLS Certificate by disabling EST following a successful enrolment. By default, automatic renewals SHOULD be **Enabled** unless a device's primary operation would be impacted by the renewal process. System administrators are strongly RECOMMENDED to monitor these devices for certificate expiry and enable EST manually at a suitable time, forcing the EST Client to perform a renewal.
+
 An EST Client SHOULD allow manual configuration of the EST Server's Hostname, Port and Arbitrary Label, to prevent the EST Client from requesting a TLS Certificate from a rogue server. The default value SHOULD be **Not Set**, enabling DNS-SD discovery.
 
 An EST Client SHOULD allow explicit trust of EST server to be disable, to prevent the EST Client from requesting a TLS Certificate from a rogue EST Server. The default value SHOULD be explicit trust of EST Server **Enabled**. More information about explicit trust of an EST Server can be found in the [Get Root CA](#get-root-ca) section.
@@ -329,7 +331,6 @@ An EST Client SHOULD periodically check the revocation status of both the Root C
 - The certificate returned by the EST Server MAY not be valid until sometime in the future
   - The 'Not Before' date MUST be checked before using the certificate
 - Care SHOULD be taken when implementing the certificate renewal process, to make sure the renewal does not affect user operation in a critical way (eg. loss of control by connected NMOS clients or affect the primary operation of the device).
-- If an EST Client cannot perform certificate renewal without affecting user operation in a critical way, then EST MAY be automatically disabled after successful certificate enrolments, preventing a renewal while the device is in use. System administrator MUST then monitor the certificate expiry and enable EST at a suitable time, forcing the EST Client to perform an enrolment.
 - Some Base64 decoding libraries expect a line length of 64 characters, however this is not required by [RFC 4648 - Section 3.1](https://tools.ietf.org/html/rfc4648#section-3.1) and some EST Server implementations do not limit the line length of encoded data.
   - EST Clients MUST be able to decode Base64 data that is not limited to 64 characters per line
 


### PR DESCRIPTION
Some devices are unable to perform a certificate renewal without
affecting the primary operation of the device. To prevent these
devices from performing a renewal while in use, a stop gap measure has been
proposed until a solution for low power devices is finalised.

The proposal is to disable EST after a successful enrolments,
allowing a system administrator to choose an appropriate time for the
device to perform the renewal by enabling EST again manually.