### PR TITLE
Replace recommended lifetime of client cert with period of 30 years

### DIFF
--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -149,7 +149,7 @@ The EST Server MUST present a valid TLS Server Certificate, this Certificate MUS
 
 The EST Server MUST authenticate the EST Client that is requesting a TLS Certificate manually or automatically using a TLS Client Certificate.
 
-The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request, including checking the TLS certificate's revocation status.
+The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request, including checking the TLS certificate's revocation status where applicable.
 
 As the TLS Client Certificate is intended to be used for the lifetime of the device, the validity of the TLS Client Certificate and its corresponding chain of trust SHOULD exceed the intended lifetime of the product, it is therefore RECOMMENDED that this is a minimum of 30 years. The EST Server MAY ignore the validity period of the TLS Client Certificate and authenticate an EST Client using an expired TLS Client Certificate, if it has not been revoked.
 

--- a/docs/1.0. Certificate Provisioning.md
+++ b/docs/1.0. Certificate Provisioning.md
@@ -149,9 +149,9 @@ The EST Server MUST present a valid TLS Server Certificate, this Certificate MUS
 
 The EST Server MUST authenticate the EST Client that is requesting a TLS Certificate manually or automatically using a TLS Client Certificate.
 
-The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request.
+The EST Server MUST support using a TLS Client Certificate, presented during the TLS handshake by the EST Client to authenticate if the EST Client is trusted. The TLS Client Certificate can either be signed by the current CA or a third party-trusted CA. The EST Server MUST check the validity of the EST Client's TLS Certificate before responding to its request, including checking the TLS certificate's revocation status.
 
-As the TLS Client Certificate is intended to be used for the lifetime of the device, the EST Server MUST support the GeneralizedTime value of 99991231235959Z for the notAfter field as defined in [RFC 5280 - Section 4.1.2](https://tools.ietf.org/html/rfc5280#section-4.1.2.5). The EST Server MAY also ignore the validity period of the client certificate and authenticate an EST Client using an expired client certificate.
+As the TLS Client Certificate is intended to be used for the lifetime of the device, the validity of the TLS Client Certificate and its corresponding chain of trust SHOULD exceed the intended lifetime of the product, it is therefore RECOMMENDED that this is a minimum of 30 years. The EST Server MAY ignore the validity period of the TLS Client Certificate and authenticate an EST Client using an expired TLS Client Certificate, if it has not been revoked.
 
 The EST Server MUST provide a method to load multiple trusted Root CA's, that are used to verify the TLS Client Certificate.
 


### PR DESCRIPTION
Remove the current recommended lifetime of 99991231235959Z with a
with a minimum of 30 years. This is due to issue with generating
CA's, intermediates and clients certs with the a notAfter date of
99991231235959Z and lifetime of products unlikely to be over 30
years.

Highlights that the Client certificate's chain of trust must
also be valid for the lifetime of the certificate for the
chain to valid.

Makes it clear that EST must check revocation status of
TLS Client Certificates.

Closes #6